### PR TITLE
Add missing express dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "body-parser": "^1.15.2",
     "google-protobuf": "^3.1.1",
     "grpc": "^1.0.1",
-    "http-server": "^0.9.0"
+    "http-server": "^0.9.0",
+    "express": "^4.15.3"
   }
 }


### PR DESCRIPTION
Without this, `node rest/server.js` fails with:

    module.js:472
        throw err;
        ^

    Error: Cannot find module 'express'
        at Function.Module._resolveFilename (module.js:470:15)
        at Function.Module._load (module.js:418:25)
        at Module.require (module.js:498:17)
        at require (internal/module.js:20:19)
        at Object.<anonymous> (/private/tmp/node-grpc-demo/rest/server.js:1:79)
        at Module._compile (module.js:571:32)
        at Object.Module._extensions..js (module.js:580:10)
        at Module.load (module.js:488:32)
        at tryModuleLoad (module.js:447:12)
        at Function.Module._load (module.js:439:3)